### PR TITLE
Adding a threshold setting to FGFXLargeScalePerceptualObscuranceIrradiance.fx

### DIFF
--- a/Shaders/FGFXLargeScalePerceptualObscuranceIrradiance.fx
+++ b/Shaders/FGFXLargeScalePerceptualObscuranceIrradiance.fx
@@ -998,9 +998,9 @@ float ThresholdedScaleOcclusionAndIrradiance(in float occlusionIrradianceOverlay
     //return 0.5 + (occlusionIrradianceOverlay - 0.5) * (occlusionIrradianceOverlay < 0.5 ? occlusionIntensity : irradianceIntensity);
 	
 	if (occlusionIrradianceOverlay <= LSPOIrrOclusionIrradianceThreshold) {
-		return 0.5 + ((occlusionIrradianceOverlay - LSPOIrrOclusionIrradianceThreshold) / (LSPOIrrOclusionIrradianceThreshold * 2)) * occlusionIntensity;
+		return 0.5 + occlusionIntensity * (occlusionIrradianceOverlay - LSPOIrrOclusionIrradianceThreshold) / (LSPOIrrOclusionIrradianceThreshold * 2);
 	} else {
-		return 0.5 + ((occlusionIrradianceOverlay - LSPOIrrOclusionIrradianceThreshold) / ((1 - LSPOIrrOclusionIrradianceThreshold) * 2)) * irradianceIntensity;
+		return 0.5 + irradianceIntensity * (occlusionIrradianceOverlay - LSPOIrrOclusionIrradianceThreshold) / ((1 - LSPOIrrOclusionIrradianceThreshold) * 2);
 	}
 }
 

--- a/Shaders/FGFXLargeScalePerceptualObscuranceIrradiance.fx
+++ b/Shaders/FGFXLargeScalePerceptualObscuranceIrradiance.fx
@@ -980,20 +980,20 @@ float3 OverlayBlend(in float3 a, in float3 b) {
     );
 }
 
-float ThresholdedScaleOcclusionAndIrradiance(in float occlusionIrradianceOverlay, in float occlusionIntensity, in float irradianceIntensity) {
+float ScaleOcclusionAndIrradiance(in float occlusionIrradianceOverlay, in float occlusionIntensity, in float irradianceIntensity) {
     // lerp(0.5, occlusionIrradianceOverlay, xxxxIntensity)
     return 0.5 + (occlusionIrradianceOverlay - 0.5) * (occlusionIrradianceOverlay < 0.5 ? occlusionIntensity : irradianceIntensity);
 }
 
-float3 ThresholdedScaleOcclusionAndIrradiance(in float3 occlusionIrradianceOverlay, in float occlusionIntensity, in float irradianceIntensity) {
+float3 ScaleOcclusionAndIrradiance(in float3 occlusionIrradianceOverlay, in float occlusionIntensity, in float irradianceIntensity) {
     return float3(
-        ThresholdedScaleOcclusionAndIrradiance(occlusionIrradianceOverlay.r, occlusionIntensity, irradianceIntensity),
-        ThresholdedScaleOcclusionAndIrradiance(occlusionIrradianceOverlay.g, occlusionIntensity, irradianceIntensity),
-        ThresholdedScaleOcclusionAndIrradiance(occlusionIrradianceOverlay.b, occlusionIntensity, irradianceIntensity)
+        ScaleOcclusionAndIrradiance(occlusionIrradianceOverlay.r, occlusionIntensity, irradianceIntensity),
+        ScaleOcclusionAndIrradiance(occlusionIrradianceOverlay.g, occlusionIntensity, irradianceIntensity),
+        ScaleOcclusionAndIrradiance(occlusionIrradianceOverlay.b, occlusionIntensity, irradianceIntensity)
     );
 }
 
-float ScaleOcclusionAndIrradiance(in float occlusionIrradianceOverlay, in float occlusionIntensity, in float irradianceIntensity) {
+float ThresholdedScaleOcclusionAndIrradiance(in float occlusionIrradianceOverlay, in float occlusionIntensity, in float irradianceIntensity) {
     // lerp(0.5, occlusionIrradianceOverlay, xxxxIntensity)
     //return 0.5 + (occlusionIrradianceOverlay - 0.5) * (occlusionIrradianceOverlay < 0.5 ? occlusionIntensity : irradianceIntensity);
 	
@@ -1004,11 +1004,11 @@ float ScaleOcclusionAndIrradiance(in float occlusionIrradianceOverlay, in float 
 	}
 }
 
-float3 ScaleOcclusionAndIrradiance(in float3 occlusionIrradianceOverlay, in float occlusionIntensity, in float irradianceIntensity) {
+float3 ThresholdedScaleOcclusionAndIrradiance(in float3 occlusionIrradianceOverlay, in float occlusionIntensity, in float irradianceIntensity) {
     return float3(
-        ScaleOcclusionAndIrradiance(occlusionIrradianceOverlay.r, occlusionIntensity, irradianceIntensity),
-        ScaleOcclusionAndIrradiance(occlusionIrradianceOverlay.g, occlusionIntensity, irradianceIntensity),
-        ScaleOcclusionAndIrradiance(occlusionIrradianceOverlay.b, occlusionIntensity, irradianceIntensity)
+        ThresholdedScaleOcclusionAndIrradiance(occlusionIrradianceOverlay.r, occlusionIntensity, irradianceIntensity),
+        ThresholdedScaleOcclusionAndIrradiance(occlusionIrradianceOverlay.g, occlusionIntensity, irradianceIntensity),
+        ThresholdedScaleOcclusionAndIrradiance(occlusionIrradianceOverlay.b, occlusionIntensity, irradianceIntensity)
     );
 }
 
@@ -1223,7 +1223,7 @@ float3 LSPOIrrPS(in float4 pos : SV_Position, in float2 texcoord : TEXCOORD) : C
 #endif // LSPOIRR_AUTO_GAIN_ENABLED
 
     // scale the overlay occlusion and irradiance components independently
-    overlayColor = ScaleOcclusionAndIrradiance(overlayColor, LSPOIrrOcclusionIntensity, LSPOIrrIrradianceIntensity);
+    overlayColor = ThresholdedScaleOcclusionAndIrradiance(overlayColor, LSPOIrrOcclusionIntensity, LSPOIrrIrradianceIntensity);
 
     // debug
     [branch]
@@ -1258,7 +1258,7 @@ float3 LSPOIrrPS(in float4 pos : SV_Position, in float2 texcoord : TEXCOORD) : C
     recoveryOverlayColor = (recoveryOverlayColor - 0.5) * LSPOIrrOcclusionIrradianceRecovery + 0.5;
 
     // scale the overlay occlusion and irradiance components independently
-    recoveryOverlayColor = ThresholdedScaleOcclusionAndIrradiance(recoveryOverlayColor, LSPOIrrIrradianceIntensity, LSPOIrrOcclusionIntensity);
+    recoveryOverlayColor = ScaleOcclusionAndIrradiance(recoveryOverlayColor, LSPOIrrIrradianceIntensity, LSPOIrrOcclusionIntensity);
 
     // debug
     [branch]

--- a/Shaders/FGFXLargeScalePerceptualObscuranceIrradiance.fx
+++ b/Shaders/FGFXLargeScalePerceptualObscuranceIrradiance.fx
@@ -196,7 +196,7 @@ uniform float LSPOIrrOclusionIrradianceThreshold < __UNIFORM_SLIDER_FLOAT1
     ui_min = 0.004;
     ui_max = 0.996;
     ui_category = ___CATEGORY_EFFECT_SETTINGS___;
-    ui_label = "Occlusion/Irradiance Threshold";
+    ui_label = "Occlusion / Irradiance Threshold";
     ui_tooltip = "Adjusts the middle line that determines what occlusion and irradiance affect.";
 > = 0.5;
 
@@ -230,7 +230,7 @@ uniform float LSPOIrrEffectSaturation < __UNIFORM_SLIDER_FLOAT1
         "\n"
         "Notice this is NOT the final output saturation, but the saturation applied to occlusion and irradiance prior to blending over the color buffer.\n"
         "For the final output saturation see 'Saturation' in the 'Toning Settings' category.";
-> = 0.0;
+> = 0.1;
 
 uniform float LSPOIrrOcclusionIrradianceRecovery < __UNIFORM_SLIDER_FLOAT1
     ui_min = 0.0;
@@ -980,20 +980,20 @@ float3 OverlayBlend(in float3 a, in float3 b) {
     );
 }
 
-float ScaleOcclusionAndIrradiance(in float occlusionIrradianceOverlay, in float occlusionIntensity, in float irradianceIntensity) {
+float ThresholdedScaleOcclusionAndIrradiance(in float occlusionIrradianceOverlay, in float occlusionIntensity, in float irradianceIntensity) {
     // lerp(0.5, occlusionIrradianceOverlay, xxxxIntensity)
     return 0.5 + (occlusionIrradianceOverlay - 0.5) * (occlusionIrradianceOverlay < 0.5 ? occlusionIntensity : irradianceIntensity);
 }
 
-float3 ScaleOcclusionAndIrradiance(in float3 occlusionIrradianceOverlay, in float occlusionIntensity, in float irradianceIntensity) {
+float3 ThresholdedScaleOcclusionAndIrradiance(in float3 occlusionIrradianceOverlay, in float occlusionIntensity, in float irradianceIntensity) {
     return float3(
-        ScaleOcclusionAndIrradiance(occlusionIrradianceOverlay.r, occlusionIntensity, irradianceIntensity),
-        ScaleOcclusionAndIrradiance(occlusionIrradianceOverlay.g, occlusionIntensity, irradianceIntensity),
-        ScaleOcclusionAndIrradiance(occlusionIrradianceOverlay.b, occlusionIntensity, irradianceIntensity)
+        ThresholdedScaleOcclusionAndIrradiance(occlusionIrradianceOverlay.r, occlusionIntensity, irradianceIntensity),
+        ThresholdedScaleOcclusionAndIrradiance(occlusionIrradianceOverlay.g, occlusionIntensity, irradianceIntensity),
+        ThresholdedScaleOcclusionAndIrradiance(occlusionIrradianceOverlay.b, occlusionIntensity, irradianceIntensity)
     );
 }
 
-float ScaleOcclusionAndIrradiance2(in float occlusionIrradianceOverlay, in float occlusionIntensity, in float irradianceIntensity) {
+float ScaleOcclusionAndIrradiance(in float occlusionIrradianceOverlay, in float occlusionIntensity, in float irradianceIntensity) {
     // lerp(0.5, occlusionIrradianceOverlay, xxxxIntensity)
     //return 0.5 + (occlusionIrradianceOverlay - 0.5) * (occlusionIrradianceOverlay < 0.5 ? occlusionIntensity : irradianceIntensity);
 	
@@ -1004,11 +1004,11 @@ float ScaleOcclusionAndIrradiance2(in float occlusionIrradianceOverlay, in float
 	}
 }
 
-float3 ScaleOcclusionAndIrradiance2(in float3 occlusionIrradianceOverlay, in float occlusionIntensity, in float irradianceIntensity) {
+float3 ScaleOcclusionAndIrradiance(in float3 occlusionIrradianceOverlay, in float occlusionIntensity, in float irradianceIntensity) {
     return float3(
-        ScaleOcclusionAndIrradiance2(occlusionIrradianceOverlay.r, occlusionIntensity, irradianceIntensity),
-        ScaleOcclusionAndIrradiance2(occlusionIrradianceOverlay.g, occlusionIntensity, irradianceIntensity),
-        ScaleOcclusionAndIrradiance2(occlusionIrradianceOverlay.b, occlusionIntensity, irradianceIntensity)
+        ScaleOcclusionAndIrradiance(occlusionIrradianceOverlay.r, occlusionIntensity, irradianceIntensity),
+        ScaleOcclusionAndIrradiance(occlusionIrradianceOverlay.g, occlusionIntensity, irradianceIntensity),
+        ScaleOcclusionAndIrradiance(occlusionIrradianceOverlay.b, occlusionIntensity, irradianceIntensity)
     );
 }
 
@@ -1223,7 +1223,7 @@ float3 LSPOIrrPS(in float4 pos : SV_Position, in float2 texcoord : TEXCOORD) : C
 #endif // LSPOIRR_AUTO_GAIN_ENABLED
 
     // scale the overlay occlusion and irradiance components independently
-    overlayColor = ScaleOcclusionAndIrradiance2(overlayColor, LSPOIrrOcclusionIntensity, LSPOIrrIrradianceIntensity);
+    overlayColor = ScaleOcclusionAndIrradiance(overlayColor, LSPOIrrOcclusionIntensity, LSPOIrrIrradianceIntensity);
 
     // debug
     [branch]
@@ -1258,7 +1258,7 @@ float3 LSPOIrrPS(in float4 pos : SV_Position, in float2 texcoord : TEXCOORD) : C
     recoveryOverlayColor = (recoveryOverlayColor - 0.5) * LSPOIrrOcclusionIrradianceRecovery + 0.5;
 
     // scale the overlay occlusion and irradiance components independently
-    recoveryOverlayColor = ScaleOcclusionAndIrradiance(recoveryOverlayColor, LSPOIrrIrradianceIntensity, LSPOIrrOcclusionIntensity);
+    recoveryOverlayColor = ThresholdedScaleOcclusionAndIrradiance(recoveryOverlayColor, LSPOIrrIrradianceIntensity, LSPOIrrOcclusionIntensity);
 
     // debug
     [branch]

--- a/Shaders/FGFXLargeScalePerceptualObscuranceIrradiance.fx
+++ b/Shaders/FGFXLargeScalePerceptualObscuranceIrradiance.fx
@@ -2,7 +2,7 @@
 
 // FGFX::LSPOIrr - Large Scale Perceptual Obscurance and Irradiance
 // Author  : Alex Tuduran | alex.tuduran@gmail.com | github.com/AlexTuduran
-// Version : 0.7 [ReShade 3.0]
+// Version : 0.7.1 [ReShade 3.0]
 
 // -------------------------------------------------------------------------- //
 // preprocessor definitions
@@ -191,6 +191,14 @@ uniform float LSPOIrrIrradianceIntensity < __UNIFORM_SLIDER_FLOAT1
     ui_label = "Irradiance Intensity";
     ui_tooltip = "Adjusts the irradiance intensity of the effect.";
 > = 1.0;
+
+uniform float LSPOIrrOclusionIrradianceThreshold < __UNIFORM_SLIDER_FLOAT1
+    ui_min = 0.004;
+    ui_max = 0.996;
+    ui_category = ___CATEGORY_EFFECT_SETTINGS___;
+    ui_label = "Occlusion/Irradiance Threshold";
+    ui_tooltip = "Adjusts the middle line that determines what occlusion and irradiance affect.";
+> = 0.5;
 
 #if ___CUSTOM_OCCLUSSION_IRRADIANCE_NEUTRAL_POINT
 
@@ -985,6 +993,25 @@ float3 ScaleOcclusionAndIrradiance(in float3 occlusionIrradianceOverlay, in floa
     );
 }
 
+float ScaleOcclusionAndIrradiance2(in float occlusionIrradianceOverlay, in float occlusionIntensity, in float irradianceIntensity) {
+    // lerp(0.5, occlusionIrradianceOverlay, xxxxIntensity)
+    //return 0.5 + (occlusionIrradianceOverlay - 0.5) * (occlusionIrradianceOverlay < 0.5 ? occlusionIntensity : irradianceIntensity);
+	
+	if (occlusionIrradianceOverlay <= LSPOIrrOclusionIrradianceThreshold) {
+		return 0.5 + ((occlusionIrradianceOverlay - LSPOIrrOclusionIrradianceThreshold) / (LSPOIrrOclusionIrradianceThreshold * 2)) * occlusionIntensity;
+	} else {
+		return 0.5 + ((occlusionIrradianceOverlay - LSPOIrrOclusionIrradianceThreshold) / ((1 - LSPOIrrOclusionIrradianceThreshold) * 2)) * irradianceIntensity;
+	}
+}
+
+float3 ScaleOcclusionAndIrradiance2(in float3 occlusionIrradianceOverlay, in float occlusionIntensity, in float irradianceIntensity) {
+    return float3(
+        ScaleOcclusionAndIrradiance2(occlusionIrradianceOverlay.r, occlusionIntensity, irradianceIntensity),
+        ScaleOcclusionAndIrradiance2(occlusionIrradianceOverlay.g, occlusionIntensity, irradianceIntensity),
+        ScaleOcclusionAndIrradiance2(occlusionIrradianceOverlay.b, occlusionIntensity, irradianceIntensity)
+    );
+}
+
 #if ___CUSTOM_OCCLUSSION_IRRADIANCE_NEUTRAL_POINT
 
 float OverlayExtendedBlend(in float a, in float b, in float pieceWiseBreakPoint) {
@@ -1196,7 +1223,7 @@ float3 LSPOIrrPS(in float4 pos : SV_Position, in float2 texcoord : TEXCOORD) : C
 #endif // LSPOIRR_AUTO_GAIN_ENABLED
 
     // scale the overlay occlusion and irradiance components independently
-    overlayColor = ScaleOcclusionAndIrradiance(overlayColor, LSPOIrrOcclusionIntensity, LSPOIrrIrradianceIntensity);
+    overlayColor = ScaleOcclusionAndIrradiance2(overlayColor, LSPOIrrOcclusionIntensity, LSPOIrrIrradianceIntensity);
 
     // debug
     [branch]

--- a/Shaders/FGFXLargeScalePerceptualObscuranceIrradiance.fx
+++ b/Shaders/FGFXLargeScalePerceptualObscuranceIrradiance.fx
@@ -995,13 +995,13 @@ float3 ScaleOcclusionAndIrradiance(in float3 occlusionIrradianceOverlay, in floa
 
 float ThresholdedScaleOcclusionAndIrradiance(in float occlusionIrradianceOverlay, in float occlusionIntensity, in float irradianceIntensity) {
     // lerp(0.5, occlusionIrradianceOverlay, xxxxIntensity)
-    //return 0.5 + (occlusionIrradianceOverlay - 0.5) * (occlusionIrradianceOverlay < 0.5 ? occlusionIntensity : irradianceIntensity);
-	
-	if (occlusionIrradianceOverlay <= LSPOIrrOclusionIrradianceThreshold) {
-		return 0.5 + occlusionIntensity * (occlusionIrradianceOverlay - LSPOIrrOclusionIrradianceThreshold) / (LSPOIrrOclusionIrradianceThreshold * 2);
-	} else {
-		return 0.5 + irradianceIntensity * (occlusionIrradianceOverlay - LSPOIrrOclusionIrradianceThreshold) / ((1 - LSPOIrrOclusionIrradianceThreshold) * 2);
-	}
+    // return 0.5 + (occlusionIrradianceOverlay - 0.5) * (occlusionIrradianceOverlay < 0.5 ? occlusionIntensity : irradianceIntensity);
+
+    if (occlusionIrradianceOverlay <= LSPOIrrOclusionIrradianceThreshold) {
+        return 0.5 + occlusionIntensity * (occlusionIrradianceOverlay - LSPOIrrOclusionIrradianceThreshold) / (LSPOIrrOclusionIrradianceThreshold * 2);
+    } else {
+        return 0.5 + irradianceIntensity * (occlusionIrradianceOverlay - LSPOIrrOclusionIrradianceThreshold) / ((1 - LSPOIrrOclusionIrradianceThreshold) * 2);
+    }
 }
 
 float3 ThresholdedScaleOcclusionAndIrradiance(in float3 occlusionIrradianceOverlay, in float occlusionIntensity, in float irradianceIntensity) {


### PR DESCRIPTION
FGFXLargeScalePerceptualObscuranceIrradiance.fx originally detects anything brighter than 0.5 as Irradiance and anything darker as Occlusion. Some games look too dark to have the _Occlusion Intensity_ on anything higher than 0.

**I added an _Occlusion/Irradiance Threshold_ setting so that you can change the line that separates Occlusion and Irradiance to any value ranging from 0.004 to 0.996.**

I did notice you have an _Occlusion-Irradiance Neutral Point_ hidden setting, but it only seems to increase/decrease the brightness. It is different from my solution, which again, tweaks the middle line between Occlusion and Irradiance.

I've been using this tweaked version of your shader in many games, and I figured it would be more convenient if this was accepted in the main file, plus other people could have access to it too.

As an extra suggestion, I would also love to have the default value of _Effect Saturation_ set to _0.1_ since it's the minimum I've used ever since I found out how beautiful games can look with it.